### PR TITLE
Support passing in dependencies directly via -f json -d file.json

### DIFF
--- a/bin/dependo
+++ b/bin/dependo
@@ -12,11 +12,9 @@ Commander
     .usage('[options] <file|dir ...>')
     .option('-f, --format <name>', 'format to parse (amd/cjs/es6/json)', 'amd')
     .option('-x, --exclude <regex>', 'a regular expression for excluding modules')
-    .option('-d, --deps <filename>', 'when used with \'-f json\', a file to load deps from in {p1:[\'c1\',\'c2\']} format')
     .parse(process.argv);
 
-
-if (Commander.format !== "json" && !Commander.args.length) {
+if (!Commander.args.length) {
   console.log(Commander.helpInformation());
   process.exit(1);
 }
@@ -24,8 +22,8 @@ if (Commander.format !== "json" && !Commander.args.length) {
 var src = Commander.args[0];
 
 var directDeps = Commander.format==='json' &&
-  fs.existsSync(Commander.deps) &&
-  JSON.parse(fs.readFileSync(Commander.deps));
+  fs.existsSync(src) &&
+  JSON.parse(fs.readFileSync(src));
 
 var dependo = new Dependo(src, {
     format: Commander.format,

--- a/bin/dependo
+++ b/bin/dependo
@@ -5,24 +5,32 @@
 var Version = require('../lib/version');
 var Commander = require('commander');
 var Dependo = require('../lib/dependo');
+var fs = require('fs');
 
 Commander
     .version(Version)
     .usage('[options] <file|dir ...>')
-    .option('-f, --format <name>', 'format to parse (amd/cjs/es6)', 'amd')
+    .option('-f, --format <name>', 'format to parse (amd/cjs/es6/json)', 'amd')
     .option('-x, --exclude <regex>', 'a regular expression for excluding modules')
+    .option('-d, --deps <filename>', 'when used with \'-f json\', a file to load deps from in {p1:[\'c1\',\'c2\']} format')
     .parse(process.argv);
 
-if (!Commander.args.length) {
-    console.log(Commander.helpInformation());
-    process.exit(1);
+
+if (Commander.format !== "json" && !Commander.args.length) {
+  console.log(Commander.helpInformation());
+  process.exit(1);
 }
 
 var src = Commander.args[0];
 
+var directDeps = Commander.format==='json' &&
+  fs.existsSync(Commander.deps) &&
+  JSON.parse(fs.readFileSync(Commander.deps));
+
 var dependo = new Dependo(src, {
     format: Commander.format,
-    exclude: Commander.exclude
+    exclude: Commander.exclude,
+    directDeps: directDeps
 });
 
 var html = dependo.generateHtml();

--- a/example/example.json
+++ b/example/example.json
@@ -1,0 +1,7 @@
+{
+  "a": ["sub/b"],
+  "d": [],
+  "fancy-main/not-index": [],
+  "sub/b": ["sub/c"],
+  "sub/c": ["d"]
+}

--- a/lib/dependo.js
+++ b/lib/dependo.js
@@ -4,13 +4,17 @@ var madge = require('madge');
 var sha1 = require('sha-1');
 
 function Dependo(targetPath, options) {
-    
+
     this.config = options || {};
     this.config.format = String(options.format || 'amd').toLowerCase();
     this.config.exclude = options.exclude || null;
     this.identification = sha1(targetPath + JSON.stringify(this.config)) || ~~(Math.random()*999999999);
 
-    this.dependencies = madge(targetPath, this.config).tree;
+    if (this.config.format==='json') {
+        this.dependencies = this.config.directDeps;
+    } else {
+        this.dependencies = madge(targetPath, this.config).tree;
+    }
 
     if (this.config.transform && typeof (this.config.transform) == 'function') {
         this.dependencies = this.config.transform(this.dependencies);

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Options
 
 ```JavaScript
 {
-    'format': The module format to expect, 'cjs', 'amd', or 'es6'. AMD (amd) is the default format.
+    'format': The module format to expect, 'cjs', 'amd', 'es6', or 'json'. AMD (amd) is the default format. If 'json', use the -d/--deps option to provide a JSON file
     'optimized': Boolean, True if the parser should read modules from a optimized file (r.js). Defaults to false.
     'exclude': String from which a regex will be constructed for excluding files from the scan.
     'mainRequireModule': Name of the module if parsing an optimized file (r.js), where the main file used require() instead of define. Defaults to ''.
@@ -84,7 +84,8 @@ CLI
 
       -h, --help             output usage information
       -V, --version          output the version number
-      -f, --format <name>    format to parse (amd/cjs)
+      -f, --format <name>    format to parse (amd/cjs/es6/json)
+      -d, --deps <file>      the file from which to read a JSON set of dependencies (only for -f json)
       -x, --exclude <regex>  a regular expression for excluding modules
 
 ### Generate HTML report of all module dependencies (AMD), and save it to /example/report.html
@@ -93,7 +94,7 @@ CLI
 
 Grunt
 -----
-I also wrote a grunt-task that can be found in this seperate repository: https://github.com/auchenberg/grunt-dependo
+I also wrote a grunt-task that can be found in this separate repository: https://github.com/auchenberg/grunt-dependo
 
 Roadmap
 -------
@@ -104,7 +105,7 @@ dependo is still very much in progress, so here is the todo-list:
 
 Thanks to
 -----------
-This project would'nt have been possible without the great work on [node-madge](https://github.com/pahen/node-madge/) by Patrik Henningson, or wonderful [D3.js](http://d3js.org/) library.
+This project wouldn't have been possible without the great work on [node-madge](https://github.com/pahen/node-madge/) by Patrik Henningson, or wonderful [D3.js](http://d3js.org/) library.
 
 
 Inspiration

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Options
 
 ```JavaScript
 {
-    'format': The module format to expect, 'cjs', 'amd', 'es6', or 'json'. AMD (amd) is the default format. If 'json', use the -d/--deps option to provide a JSON file
+    'format': The module format to expect, 'cjs', 'amd', 'es6', or 'json'. AMD (amd) is the default format. If 'json', pass a file formatted like `example.json` in the `example/` directory.
     'optimized': Boolean, True if the parser should read modules from a optimized file (r.js). Defaults to false.
     'exclude': String from which a regex will be constructed for excluding files from the scan.
     'mainRequireModule': Name of the module if parsing an optimized file (r.js), where the main file used require() instead of define. Defaults to ''.
@@ -85,7 +85,6 @@ CLI
       -h, --help             output usage information
       -V, --version          output the version number
       -f, --format <name>    format to parse (amd/cjs/es6/json)
-      -d, --deps <file>      the file from which to read a JSON set of dependencies (only for -f json)
       -x, --exclude <regex>  a regular expression for excluding modules
 
 ### Generate HTML report of all module dependencies (AMD), and save it to /example/report.html


### PR DESCRIPTION
With example.json containing:
`{"a":["sub/b"],"d":[],"fancy-main/not-index":[],"sub/b":["sub/c"],"sub/c":["d"]}`

New feature:
`./bin/dependo -f json -d example.json > example/index.html ; open example/index.html`
Regression tested with:
`./bin/dependo -f cjs lib/ > example/index.html ; open example/index.html`

